### PR TITLE
Routing and Implementation of React Concepts

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "bootstrap": "^5.3.3",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.56",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,16 @@
+import type { ReactElement } from "react";
 import NavBar from "./components/NavBar/NavBar";
+import { Outlet } from "react-router-dom";
 
-function App()
+function App(): ReactElement
 {
-   return <body>
-      <div>
+   return (
+      <>
          <NavBar />
-      </div>
-   </body>
+         <Outlet /> {/* Renders the element based on the route from `createBrowserRouter` in `main.tsx`. */}
+         {/* TODO: Add a Footer component here later, if desired. */}
+      </>
+   );
 }
 
 export default App;

--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -1,0 +1,11 @@
+import type { ReactElement } from "react";
+
+function Home(): ReactElement {
+	return (
+		<>
+			<h1>Hello World!</h1>
+		</>
+	);
+}
+
+export default Home;

--- a/src/components/MembersPage/MembersPage.css
+++ b/src/components/MembersPage/MembersPage.css
@@ -1,0 +1,12 @@
+.members {
+	display: flex;
+	flex-direction: row;
+}
+
+.member-card {
+	display: block;
+	border: 1px solid #ccc;
+	border-radius: 5px;
+	padding: 5px 10px;
+	margin: 5px 10px;
+}

--- a/src/components/MembersPage/MembersPage.tsx
+++ b/src/components/MembersPage/MembersPage.tsx
@@ -1,0 +1,27 @@
+import type { ReactElement } from "react";
+import "./MembersPage.css";
+import exeMembers from "../../exe-members/data.json";
+
+function MembersPage(): ReactElement {
+	
+	return (
+		<>
+			<h1>.EXE Members</h1>
+
+			<div className="members">
+				{
+					exeMembers.members.map((member, i) => {
+						return (
+							<div className="member-card" key={i}>
+								<h3>{member.name}</h3>
+								<span>{member.role}</span>
+							</div>
+						);
+					})
+				}
+			</div>
+		</>
+	);
+}
+
+export default MembersPage;

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -1,36 +1,42 @@
 import './NavBar.css';
+import { Link } from "react-router-dom";
 
 function NavBar()
 {
    return (
-   <>
-   <nav className="navbar navbar-expand-lg ">
-      <div className="container-fluid">
-         <a className="navbar-brand">.EXE</a>
-         <button className="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-            <span className="navbar-toggler-icon"></span>
-    </button>
-    
-    <div className="collapse navbar-collapse" id="navbarNav">
-      <ul className="navbar-nav">
+     <>
+      <nav className="navbar navbar-expand-lg ">
+        <div className="container-fluid">
+           <Link to="./" className="navbar-brand">.EXE</Link>
+           <button className="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+              <span className="navbar-toggler-icon"></span>
+      </button>
+      
+      <div className="collapse navbar-collapse" id="navbarNav">
+        <ul className="navbar-nav">
 
-        <li className="nav-item">
-          <a className="nav-link active" aria-current="page" href="./src/assets/testing.pdf">Other</a>
-        </li>
-        
-        <li className="nav-item">
-          <a className="nav-link" href="">GitHub</a>
-        </li>
+          <li className="nav-item">
+            <Link className="nav-link active" aria-current="page" to="./src/assets/testing.pdf">Other</Link>
+          </li>
+          
+          <li className="nav-item">
+            <Link className="nav-link" to="https://github.com/TXSTDOTEXE/Website" target="_blank">GitHub</Link>
+          </li>
 
-        <li className="nav-item">
-          <a className="nav-link" href= "" >Links</a>
-        </li>
+          <li className="nav-item">
+            <Link className="nav-link" to="./members">Members</Link>
+          </li>
+          
 
-       </ul>
-    </div>
+          <li className="nav-item">
+            <Link className="nav-link" to= "" target="_blank">Links</Link>
+          </li>
+
+         </ul>
       </div>
-    </nav>
-   </> 
+        </div>
+      </nav>
+     </> 
    );  
 }
 

--- a/src/components/NotFound/NotFound.tsx
+++ b/src/components/NotFound/NotFound.tsx
@@ -1,0 +1,24 @@
+import type { ReactElement } from "react";
+import { useLocation } from "react-router-dom";
+
+function NotFound() {
+	const { pathname } = useLocation();
+
+	const currentPath = pathname.split("/") // Splits the string into an array based on the given separator.
+																					// In this case, "/" that separate parts of the URL.
+															.toSpliced(1, 1) // Removes "Website" from the array and returns a new array.
+															.join("/"); // Join the array back together into a string
+
+	return (
+		<>
+			<h3>Page Not Found</h3>
+			<p>
+				Ops! It appears you encountered a <code>404</code> error.<br />
+				This error occurred because the url you tried to go to, "<i>{currentPath}</i>",
+				does not exist.
+			</p>
+		</>
+	);
+}
+
+export default NotFound;

--- a/src/exe-members/data.json
+++ b/src/exe-members/data.json
@@ -1,0 +1,24 @@
+{
+	"members": [
+		{
+			"name": "Lorenz",
+			"role": "President"
+		},
+		{
+			"name": "Wyatt",
+			"role": "Vice President"
+		},
+		{
+			"name": "James",
+			"role": "Secretary"
+		},
+		{
+			"name": "Carson",
+			"role": "Officer"
+		},
+		{
+			"name": "Mark",
+			"role": "Officer"
+		}
+	]
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,46 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
-import 'bootstrap/dist/css/bootstrap.css'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.tsx';
+import Home from './components/Home/Home.tsx';
+import MembersPage from './components/MembersPage/MembersPage.tsx';
+import NotFound from './components/NotFound/NotFound.tsx';
+import 'bootstrap/dist/css/bootstrap.css';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/js/bootstrap.bundle.min';
 
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
+
+/**
+ * The webpage's routes. Add or delete routes if needed.
+ * Make sure to create routes in the array of the children property.
+ */
+const browserRouter = createBrowserRouter([
+ {
+  path: "/Website",
+  element: App(),
+  children: [
+    {
+      path: "/Website/",
+      element: Home()
+    },
+    {
+      path: "/Website/members",
+      element: MembersPage()
+    },
+
+    // Add more routes here if needed...
+
+    // Below is to handle non-existant urls
+    {
+      path: "*",
+      element: <NotFound />
+    }
+  ]
+ },
+]);
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <RouterProvider router={browserRouter} />
   </React.StrictMode>,
 )


### PR DESCRIPTION
Added Routing. However, it may be possible that we may have to add scripts to the `index.html` and `404.html` (created on our own) to solve a routing problem where GH pages doesn't know how to route when refreshing the app if the current URL is not the root. If this does happen, we can solve it by following [this](https://github.com/rafgraph/spa-github-pages).

Also attempting to think of ways to implement React concepts.

React Concepts to implement (may be changed overtime to accommodate to new ideas):
- [ ] State ([`useState`](https://react.dev/reference/react/useState))
- [ ] Side Effects ([`useEffect`](https://react.dev/reference/react/useEffect))
- [x] Using JavaScript to render JSX/TSX ([Rendering Lists](https://react.dev/learn/rendering-lists), [Curly Brace Syntax](https://react.dev/learn/javascript-in-jsx-with-curly-braces))